### PR TITLE
Updating README for the C++ implementation

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,19 +1,20 @@
 CXX = g++
-CXXFLAGS = -g -O2
-LDFLAGS += -lmesos
+CXXFLAGS = -g -O2 -pthread
+LDFLAGS += -lmesos -lpthread -lprotobuf
 CXXCOMPILE = $(CXX) $(INCLUDES) $(CXXFLAGS) -c -o $@
-CXXLINK = $(CXX) $(INCLUDES) $(CXXFLAGS) $(LDFLAGS) -o $@
+CXXLINK = $(CXX) $(INCLUDES) $(CXXFLAGS) -o $@
 
 default: all
 all: rendler crawl_executor render_executor
 
 HEADERS = rendler_helper.hpp
 
+
 crawl_executor: crawl_executor.cpp $(HEADERS)
-	$(CXXLINK) $< -lboost_regex -lcurl
+	$(CXXLINK) $<  $(LDFLAGS) -lboost_regex -lcurl
 
 %: %.cpp $(HEADERS)
-	$(CXXLINK) $<
+	$(CXXLINK) $< $(LDFLAGS)
 
 check: crawl
 	./crawl http://mesosphere.io/team/

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -6,7 +6,7 @@ Dependencies:
 - libboost_regex.so
 - libcurl.so
 - libprotobuf.so
-- lib
+- google log
 - Makefile assumes all 3rdparty libraries/headers to be available in the
   default include path (/usr/include?).
 - render.js present in the parent directory.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -41,14 +41,14 @@ $ vagrant ssh
 vagrant@mesos:~ $ cd hostfiles/cpp
 
 # Update install dependencies
-vagrant@mesos:~ $ sudo apt-get update
-vagrant@mesos:~ $ sudo apt-get install libcurl4-openssl-dev libboost-regex1.55-dev \
+vagrant@mesos:cpp $ sudo apt-get update
+vagrant@mesos:cpp $ sudo apt-get install libcurl4-openssl-dev libboost-regex1.55-dev \
 				  libprotobuf-dev libgoogle-glog-dev protobuf-compiler
 
 # Build
-vagrant@mesos:~ $ make all
+vagrant@mesos:cpp $ make all
 
 # Start the scheduler with the seed url, the mesos master ip
-vagrant@mesos:python $ rendler --seedUrl http://mesosphere.io --master 127.0.1.1:5050
+vagrant@mesos:cpp $ rendler --seedUrl http://mesosphere.io --master 127.0.1.1:5050
 # <Ctrl+C> to stop...
 ```

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -5,6 +5,8 @@ Dependencies:
 ============
 - libboost_regex.so
 - libcurl.so
+- libprotobuf.so
+- lib
 - Makefile assumes all 3rdparty libraries/headers to be available in the
   default include path (/usr/include?).
 - render.js present in the parent directory.
@@ -30,3 +32,23 @@ Communication between Scheduler and Executors:
 - Each framework message consists of a vector of strings:
   RenderExecuter->Scheduler:    { taskId, taskUrl, filepath }
   CrawlExecuter->Scheduler:     { taskId, taskUrl, <urls>+ }
+
+Execution:
+=========
+
+```bash
+$ vagrant ssh
+vagrant@mesos:~ $ cd hostfiles/cpp
+
+# Update install dependencies
+vagrant@mesos:~ $ sudo apt-get update
+vagrant@mesos:~ $ sudo apt-get install libcurl4-openssl-dev libboost-regex1.55-dev \
+				  libprotobuf-dev libgoogle-glog-dev protobuf-compiler
+
+# Build
+vagrant@mesos:~ $ make all
+
+# Start the scheduler with the seed url, the mesos master ip
+vagrant@mesos:python $ rendler --seedUrl http://mesosphere.io --master 127.0.1.1:5050
+# <Ctrl+C> to stop...
+```


### PR DESCRIPTION
Moved the `README` to be a markdown file so is properly parsed by github. Also the link in the main `README.md` was broken, the renaming fixed that.

Update the dependency list and created a step by step instructions on how to build and run the framework.