### PR TITLE
s/mesos.box/mesoscon.box

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ RENDLER consists of three main components:
 ### Start the `mesos-demo` VM
 
 ```bash
-$ wget http://downloads.mesosphere.io/demo/mesos.box -O /tmp/mesos.box
-$ vagrant box add --name mesos-demo /tmp/mesos.box
+$ wget http://downloads.mesosphere.io/demo/mesoscon.box -O /tmp/mesoscon.box
+$ vagrant box add --name mesos-demo /tmp/mesoscon.box
 $ git clone https://github.com/mesosphere/RENDLER.git
 $ cd RENDLER
 $ vagrant up


### PR DESCRIPTION
mesos.box doesn't seem to work.  I get this error:

```
Traceback (most recent call last):
 File "rendler.py", line 17, in <module>
   from mesos import Executor, MesosExecutorDriver, MesosSchedulerDriver, Scheduler
ImportError: cannot import name Executor
```

Works for me with mesoscon.box.  I suppose it's a mesos versioning issue, but I'm not sure.