### PR TITLE
C++ build fixes

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -g -O2 -pthread
+CXXFLAGS = -g -O2 -pthread -std=c++0x
 LDFLAGS += -lmesos -lpthread -lprotobuf
 CXXCOMPILE = $(CXX) $(INCLUDES) $(CXXFLAGS) -c -o $@
 CXXLINK = $(CXX) $(INCLUDES) $(CXXFLAGS) -o $@

--- a/cpp/rendler.cpp
+++ b/cpp/rendler.cpp
@@ -102,7 +102,7 @@ public:
           ";mem:" + stringify<size_t>(MEM_PER_TASK)).get();
 
       size_t maxTasks = 0;
-      while (TASK_RESOURCES <= remaining) {
+      while (remaining.flatten().contains(TASK_RESOURCES)) {
         maxTasks++;
         remaining -= TASK_RESOURCES;
       }


### PR DESCRIPTION
Two fixes for the C++ version:
* `std::initializer_list` requires C++11
* mesos::Resource does not overload the `<=` operator.  Some other examples use `.contains(...)` instead.