### PR TITLE
Update README.md

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -5,6 +5,6 @@ Python Rendler Framework
 $ vagrant ssh
 vagrant@mesos:~ $ cd hostfiles
 # Start the scheduler with the seed url, the mesos master ip and optionally a task limit 
-vagrant@mesos:python $ python python/rendler.py http://mesosphere.io 127.0.1.1:5050 42
+vagrant@mesos:python $ python python/rendler.py http://mesos.apache.org 127.0.1.1:5050 10
 # <Ctrl+C> to stop...
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -3,8 +3,8 @@ Python Rendler Framework
 
 ```bash
 $ vagrant ssh
-vagrant@mesos:~ $ cd hostfiles/python
+vagrant@mesos:~ $ cd hostfiles
 # Start the scheduler with the seed url, the mesos master ip and optionally a task limit 
-vagrant@mesos:python $ python rendler.py http://mesosphere.io 127.0.1.1:5050 42
+vagrant@mesos:python $ python python/rendler.py http://mesosphere.io 127.0.1.1:5050 42
 # <Ctrl+C> to stop...
 ```


### PR DESCRIPTION
Run from hostfiles directory, so the result.dot file will be written there, and the subsequent "bin/make-pdf" will correctly work.

I ran into this problem at the mesoscon 2015 framework workshop.  Workshop runners told me this is a known issue, and to create a pull request.

I also changed the example command from mesosphere.io (which didn't work) to mesos.apache.org (which did) and lowered the limit to 10 tasks.