### PR TITLE
cpp: Fix compilation warnings.

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -g -O2 -pthread -std=c++0x
+CXXFLAGS = -Wall -g -O2 -pthread -std=c++0x
 LDFLAGS += -lmesos -lpthread -lprotobuf
 CXXCOMPILE = $(CXX) $(INCLUDES) $(CXXFLAGS) -c -o $@
 CXXLINK = $(CXX) $(INCLUDES) $(CXXFLAGS) -o $@

--- a/cpp/render_executor.cpp
+++ b/cpp/render_executor.cpp
@@ -42,13 +42,6 @@ struct TaskLaunchInfo {
   TaskInfo       *task;
 };
 
-static int writer(char *data, size_t size, size_t nmemb, string *writerData)
-{
-  assert(writerData != NULL);
-  writerData->append(data, size*nmemb);
-  return size * nmemb;
-}
-
 static void runTask(ExecutorDriver* driver, const TaskInfo& task)
 {
   string url = task.data();

--- a/cpp/rendler.cpp
+++ b/cpp/rendler.cpp
@@ -55,7 +55,7 @@ static size_t nextUrlId = 0;
 MesosSchedulerDriver* schedulerDriver;
 
 static void shutdown();
-static void SIGINTHandler();
+static void SIGINTHandler(int signum);
 
 class Rendler : public Scheduler
 {


### PR DESCRIPTION
Warnings are harmless but easy to fix. This commit also adds "-Wall" to the
default CXXFLAGS.