### PR TITLE
Don't wait for pending framework messages.

### DIFF
--- a/cpp/rendler.cpp
+++ b/cpp/rendler.cpp
@@ -157,10 +157,13 @@ public:
     if (tasksFinished == tasksLaunched &&
         crawlQueue.empty() &&
         renderQueue.empty()) {
-      // Wait to receive any pending framework messages
-      // If some framework messages are lost, it may hang indefinitely.
-      while (frameworkMessagesReceived != tasksFinished) {
-        sleep(1);
+      // We don't wait to receive pending framework messages, if any. Framework
+      // messages are not reliable, so we can't easily recover dropped messages
+      // anyway.
+      int missing_messages = tasksFinished - frameworkMessagesReceived;
+      if (missing_messages > 0) {
+        cout << "Noticed that " << missing_messages
+             << " framework messages were not received" << endl;
       }
       shutdown();
       driver->stop();


### PR DESCRIPTION
The previous coding is misleading: only one scheduler callback will be invoked
at any time. Hence, sleeping in a loop inside one scheduler callback and waiting
for additional callbacks to be invoked cannot be a good idea.

We could try other, fancier approaches to recovering dropped messages (e.g.,
framework-level acknowledgment/retry scheme), but that seems out of scope:
simpler to just exit.