### PR TITLE
Explicitly specify a parser

### DIFF
--- a/python/crawl_executor.py
+++ b/python/crawl_executor.py
@@ -69,7 +69,7 @@ class CrawlExecutor(Executor):
                 print error_msg
                 return
                 
-            soup = BeautifulSoup(source)
+            soup = BeautifulSoup(source, "lxml")
 
             links = []
             try:


### PR DESCRIPTION
Prevents a user warning when no parser is explicitly specified. This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.